### PR TITLE
windows CI: bump java to version 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ commands:
           name: Preparing environment - system
           command: |
             choco install -y --no-progress miniconda3
-            choco install -y --no-progress openssl javaruntime
+            choco install -y --no-progress openssl openjdk11jre
             C:\tools\miniconda3\Scripts\conda.exe init powershell
       - run:
           name: Preparing environment - Hydra


### PR DESCRIPTION
This PR is an attempt to resolve the windows CI issue seen in https://github.com/facebookresearch/hydra/pull/2733.
Upgrades to Java SE 11 (which matches the Java version used in the linux CI).